### PR TITLE
Importer Umami analytics events riktig så de ikke blir undefined

### DIFF
--- a/din-uforetrygd-frontend/src/components/DocumentLink/DocumentLink.tsx
+++ b/din-uforetrygd-frontend/src/components/DocumentLink/DocumentLink.tsx
@@ -1,6 +1,6 @@
 import { ExternalLinkIcon } from '@navikt/aksel-icons'
 import { Detail, Link, VStack } from '@navikt/ds-react'
-import { LAST_NED_EVENT } from '@navikt/nav-dekoratoren-moduler'
+import { Events } from '@navikt/nav-dekoratoren-moduler'
 import type React from 'react'
 import { readableFileSize } from '@/components/DocumentLink/utils'
 import { umami } from '@/utils/umami'
@@ -21,7 +21,7 @@ export const DocumentLink: React.FC<IDocumentLink> = (props) => {
         className={styles.link}
         onClick={(e) => {
           e.stopPropagation()
-          umami(LAST_NED_EVENT, { type: 'Saksdokument', tema: 'Uføretrygd', tittel: 'Dokument' })
+          umami(Events.LAST_NED, { type: 'Saksdokument', tema: 'Uføretrygd', tittel: 'Dokument' })
         }}
       >
         {props.children}

--- a/din-uforetrygd-frontend/src/components/Dokumenter/DokumenterView.tsx
+++ b/din-uforetrygd-frontend/src/components/Dokumenter/DokumenterView.tsx
@@ -3,7 +3,7 @@
 import { FolderFileIcon } from '@navikt/aksel-icons'
 import { BodyShort, Box, ExpansionCard, Hide, HStack, VStack } from '@navikt/ds-react'
 import { LinkCardIcon } from '@navikt/ds-react/LinkCard'
-import { ACCORDION_APNET_EVENT } from '@navikt/nav-dekoratoren-moduler'
+import { Events } from '@navikt/nav-dekoratoren-moduler'
 import type React from 'react'
 import { DocumentLink } from '@/components/DocumentLink/DocumentLink'
 import { getDocumentProxyLink } from '@/components/Dokumenter/utils'
@@ -45,7 +45,7 @@ export const DokumenterView: React.FC<IDokumenterProps> = (props) => {
             <ExpansionCard.Title
               size="small"
               className={styles.dokumenterCardTitle}
-              onClick={() => umami(ACCORDION_APNET_EVENT, { tittel: 'Dokumenter knyttet til saken din' })}
+              onClick={() => umami(Events.ACCORDION_APNET, { tittel: 'Dokumenter knyttet til saken din' })}
             >
               Dokumenter knyttet til saken din
             </ExpansionCard.Title>

--- a/din-uforetrygd-frontend/src/components/ReadMoreTile/ReadMoreTile.tsx
+++ b/din-uforetrygd-frontend/src/components/ReadMoreTile/ReadMoreTile.tsx
@@ -2,7 +2,7 @@
 
 import { ChevronDownIcon, ChevronUpIcon } from '@navikt/aksel-icons'
 import { Box, VStack } from '@navikt/ds-react'
-import { ACCORDION_APNET_EVENT } from '@navikt/nav-dekoratoren-moduler'
+import { Events } from '@navikt/nav-dekoratoren-moduler'
 import { useState } from 'react'
 import { umami } from '@/utils/umami'
 import styles from './readmoretile.module.css'
@@ -19,7 +19,7 @@ export const ReadMoreTile: React.FC<IReadMoreTileProps> = (props) => {
       setIsOpen(false)
     } else {
       setIsOpen(true)
-      umami(ACCORDION_APNET_EVENT, { tittel: 'Dokument' })
+      umami(Events.ACCORDION_APNET, { tittel: 'Dokument' })
     }
   }
 

--- a/din-uforetrygd-frontend/src/sections/DittVedtak/Vedtaksdetaljer.tsx
+++ b/din-uforetrygd-frontend/src/sections/DittVedtak/Vedtaksdetaljer.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { BodyShort, Box, Heading, HelpText, HGrid, HStack, Link, List, Table, VStack } from '@navikt/ds-react'
-import { HELPTEXT_VIST_EVENT } from '@navikt/nav-dekoratoren-moduler'
+import { Events } from '@navikt/nav-dekoratoren-moduler'
 import { format, parseISO } from 'date-fns'
 import type { DittUforevedtak } from '@/api/initiate'
 import styles from '@/sections/DittVedtak/dittvedtak.module.css'
@@ -122,7 +122,7 @@ export function Vedtaksdetaljer({
                     <BodyShort>Registrert forventet inntekt i {arstall}</BodyShort>
                     <HelpText
                       title="Hvor kommer registrert forventet inntekt fra?"
-                      onClick={() => umami(HELPTEXT_VIST_EVENT, { tekst: 'Registrert forventet inntekt' })}
+                      onClick={() => umami(Events.HELPTEXT_VIST, { tekst: 'Registrert forventet inntekt' })}
                     >
                       Forventet inntekt kommer fra dine tidligere registreringer, eller i noen tilfeller fra
                       opplysninger vi har hentet. Har du nylig meldt inn inntekt, vil den ikke vises her før den har
@@ -144,7 +144,7 @@ export function Vedtaksdetaljer({
                     <BodyShort>Inntektsgrense</BodyShort>
                     <HelpText
                       title="Hva er inntektsgrense?"
-                      onClick={() => umami(HELPTEXT_VIST_EVENT, { tekst: 'Inntektsgrense' })}
+                      onClick={() => umami(Events.HELPTEXT_VIST, { tekst: 'Inntektsgrense' })}
                     >
                       Den årlige inntekten du kan ha, før vi reduserer uføretrygden din
                     </HelpText>
@@ -161,7 +161,7 @@ export function Vedtaksdetaljer({
                       <BodyShort>Reduksjonsprosent</BodyShort>
                       <HelpText
                         title="Hva er reduksjonsprosent?"
-                        onClick={() => umami(HELPTEXT_VIST_EVENT, { tekst: 'reduksjonsprosent' })}
+                        onClick={() => umami(Events.HELPTEXT_VIST, { tekst: 'reduksjonsprosent' })}
                       >
                         <BodyShort spacing>
                           Vi trekker en prosent lik reduksjonsprosenten fra uføretrygden av hver krone du tjener over
@@ -195,7 +195,7 @@ export function Vedtaksdetaljer({
                     <BodyShort>Inntektstak i {arstall}</BodyShort>{' '}
                     <HelpText
                       title="Hva er inntektstak?"
-                      onClick={() => umami(HELPTEXT_VIST_EVENT, { tekst: 'Inntektstak' })}
+                      onClick={() => umami(Events.HELPTEXT_VIST, { tekst: 'Inntektstak' })}
                     >
                       Den årlige inntekten du kan ha, før du ikke lenger får utbetalt uføretrygd det aktuelle året.
                       Inntektstaket er 80 prosent av inntekten du hadde før uførhet, oppjustert til dagens verdi.

--- a/din-uforetrygd-frontend/src/sections/ForsideBehandling/SøknadInnvilget.tsx
+++ b/din-uforetrygd-frontend/src/sections/ForsideBehandling/SøknadInnvilget.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Heading, HelpText, HGrid, HStack, Link } from '@navikt/ds-react'
-import { HELPTEXT_VIST_EVENT } from '@navikt/nav-dekoratoren-moduler'
+import { Events } from '@navikt/nav-dekoratoren-moduler'
 import Divider from '@/sections/ForsideBehandling/Divider'
 import { ForsideBehandlingHeader } from '@/sections/ForsideBehandling/ForsideBehandlingHeader'
 import type { ForsideBehandling } from '@/sections/ForsideBehandling/forsideBehandlingUtil'
@@ -26,7 +26,7 @@ export const SøknadInnvilget = ({ behandling }: Props) => {
         <Heading size="small">Ny månedlig beregning før skatt</Heading>
         <HelpText
           title={'Om månedlig beregning'}
-          onClick={() => umami(HELPTEXT_VIST_EVENT, { tekst: 'Månedlig beregning' })}
+          onClick={() => umami(Events.HELPTEXT_VIST, { tekst: 'Månedlig beregning' })}
         >
           Dette er ikke beløpet du får utbetalt på konto. Det trekkes skatt, eventuelle lønnstrekk og andre trekk før du
           får det utbetalt.


### PR DESCRIPTION
Sånn vi importerte eventene tidligere så blir bare konstantene undefined og umami kaster exception når vi prøver å tracke hendelser: `UnhandledRejection: Non-Error promise rejection captured with value: Parameter "eventName" must be a string`

Oppdaget feilen i Grafana: https://grafana.nav.cloud.nais.io/a/nais-apm-app/services/ufore/din-uforetrygd-frontend-borger?favorites=true&environment=prod&tab=issues&issueId=v1%3A8bbf5b4ce91d5519&exceptionSessionId=RZ4VWRLQmy

Dokumentasjon på fiksen: https://github.com/navikt/analytics-types