### PR TITLE
Fiks bug hvor verge variabel ikke kunne hentes fra backend response

### DIFF
--- a/din-uforetrygd-backend/src/main/kotlin/no/nav/dinuforetrygd/uforetrygd/ForsideService.kt
+++ b/din-uforetrygd-backend/src/main/kotlin/no/nav/dinuforetrygd/uforetrygd/ForsideService.kt
@@ -17,7 +17,6 @@ import no.nav.dinuforetrygd.security.TokenService
 import no.nav.dinuforetrygd.util.erRelevant
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 
 @Service
@@ -38,7 +37,7 @@ class ForsideService(
             if (uforeSak == null) return@withContext lagUforetrygdResponse(
                 pid = pid,
                 sak = null,
-                isVerge = isUforetrygdVerge(pid)
+                erVerge = isUforetrygdVerge(pid)
             )
 
             val vedtakssammendragResponseDeferred = async { penService.getVedtakssammendrag(pid) }
@@ -53,12 +52,12 @@ class ForsideService(
                 }
             }
 
-            val isVergeDeferred = async { isUforetrygdVerge(pid) }
+            val erVergeDeferred = async { isUforetrygdVerge(pid) }
 
             val vedtakssammendragResponse = vedtakssammendragResponseDeferred.await()
             val sumAvForventedeInntekter = sumAvForventedeInntekterDeferred.await()
             val forsideData = forsideDataDeferred.await()
-            val isVerge = isVergeDeferred.await()
+            val erVerge = erVergeDeferred.await()
 
             var inntektFraSkatt = 0.0
 
@@ -76,7 +75,7 @@ class ForsideService(
                 hasIverksattVedtak = vedtakssammendragResponse.hasIverksattVedtak,
                 uforevedtak = vedtakssammendragResponse.vedtakssammendrag?.toDittUforeVedtak(sumAvForventedeInntekter, inntektFraSkatt),
                 behandling = forsideData?.let { finnAktivBehandling(forsideData.apentKrav, forsideData.vedtakIverksattSiste7Dager) },
-                isVerge = isVerge
+                erVerge = erVerge
             )
         }
     }
@@ -105,16 +104,15 @@ class ForsideService(
         hasIverksattVedtak: Boolean = false,
         uforevedtak: DittUforevedtak? = null,
         behandling: Behandling? = null,
-        isVerge: Boolean
+        erVerge: Boolean
     ) = UforetrygdResponse(
         pid = pid,
-        loggetInnSom = tokenService.determineLoggedInUser(),
         sak = sak,
         innloggingstype = tokenService.getInnloggingstype(),
         hasIverksattVedtak = hasIverksattVedtak,
         uforevedtak = uforevedtak,
         behandling = behandling,
-        isVerge = isVerge
+        erVerge = erVerge
     )
 
     private fun Vedtakssammendrag.toDittUforeVedtak(sumAvForventedeInntekter: Long?, inntektFraSkatt: Double): DittUforevedtak =

--- a/din-uforetrygd-backend/src/main/kotlin/no/nav/dinuforetrygd/uforetrygd/UforetrygdResponse.kt
+++ b/din-uforetrygd-backend/src/main/kotlin/no/nav/dinuforetrygd/uforetrygd/UforetrygdResponse.kt
@@ -4,13 +4,12 @@ import java.time.LocalDate
 
 data class UforetrygdResponse(
     val pid: String,
-    val loggetInnSom: String,
     val sak: Sak?,
     val hasIverksattVedtak: Boolean,
     val uforevedtak: DittUforevedtak?,
     val innloggingstype: Innloggingstype,
     val behandling: Behandling? = null,
-    val isVerge: Boolean
+    val erVerge: Boolean
 )
 
 data class DittUforevedtak(

--- a/din-uforetrygd-frontend/mock/mockData.ts
+++ b/din-uforetrygd-frontend/mock/mockData.ts
@@ -3,7 +3,6 @@ import type { UforetrygdResponse } from '../src/api/initiate'
 export const mockData: Record<string, UforetrygdResponse> = {
   default: {
     pid: '81549300',
-    loggetInnSom: '81549300',
     sak: {
       status: 'LOPENDE',
       sakId: 519023581092,
@@ -25,7 +24,7 @@ export const mockData: Record<string, UforetrygdResponse> = {
       hasVarigTilrettelagtArbeid: false,
     },
     innloggingstype: 'LEVEL3',
-    verge: true,
+    erVerge: true,
     behandling: {
       type: 'SØKNAD_UFØRETRYGD',
       status: 'INNVILGET',
@@ -36,7 +35,6 @@ export const mockData: Record<string, UforetrygdResponse> = {
   },
   avsluttet: {
     pid: '81549300',
-    loggetInnSom: '81549300',
     sak: { status: 'AVSLUTTET' },
     hasIverksattVedtak: false,
     uforevedtak: {
@@ -55,11 +53,10 @@ export const mockData: Record<string, UforetrygdResponse> = {
       hasVarigTilrettelagtArbeid: false,
     },
     innloggingstype: 'LEVEL4',
-    verge: false,
+    erVerge: false,
   },
   gradert: {
     pid: '81549300',
-    loggetInnSom: '81549300',
     sak: { status: 'LOPENDE' },
     hasIverksattVedtak: true,
     uforevedtak: {
@@ -78,29 +75,26 @@ export const mockData: Record<string, UforetrygdResponse> = {
       hasVarigTilrettelagtArbeid: false,
     },
     innloggingstype: 'LEVEL4',
-    verge: false,
+    erVerge: false,
   },
   'har-lopende': {
     pid: '81549300',
-    loggetInnSom: '81549300',
     sak: { status: 'LOPENDE' },
     hasIverksattVedtak: false,
     uforevedtak: undefined,
     innloggingstype: 'LEVEL4',
-    verge: false,
+    erVerge: false,
   },
   'sak-behandling': {
     pid: '81549300',
-    loggetInnSom: '81549300',
     sak: { status: 'TIL_BEHANDLING' },
     hasIverksattVedtak: false,
     uforevedtak: undefined,
     innloggingstype: 'LEVEL4',
-    verge: false,
+    erVerge: false,
   },
   'ufore-behandling': {
     pid: '81549300',
-    loggetInnSom: '81549300',
     sak: { status: 'TIL_BEHANDLING' },
     hasIverksattVedtak: true,
     uforevedtak: {
@@ -119,20 +113,18 @@ export const mockData: Record<string, UforetrygdResponse> = {
       hasVarigTilrettelagtArbeid: false,
     },
     innloggingstype: 'LEVEL4',
-    verge: false,
+    erVerge: false,
   },
   'ingen-uforesak': {
     pid: '81549300',
-    loggetInnSom: '81549300',
     sak: undefined,
     hasIverksattVedtak: false,
     uforevedtak: undefined,
     innloggingstype: 'LEVEL4',
-    verge: false,
+    erVerge: false,
   },
   'ufore-uten-datoer': {
     pid: '81549300',
-    loggetInnSom: '81549300',
     sak: { status: 'LOPENDE' },
     hasIverksattVedtak: true,
     uforevedtak: {
@@ -151,6 +143,6 @@ export const mockData: Record<string, UforetrygdResponse> = {
       hasVarigTilrettelagtArbeid: false,
     },
     innloggingstype: 'LEVEL4',
-    verge: false,
+    erVerge: false,
   },
 }

--- a/din-uforetrygd-frontend/src/api/initiate.ts
+++ b/din-uforetrygd-frontend/src/api/initiate.ts
@@ -58,11 +58,10 @@ export interface Sak {
 
 export interface UforetrygdResponse {
   pid?: string
-  loggetInnSom?: string
   sak?: Sak
   hasIverksattVedtak: boolean
   uforevedtak?: DittUforevedtak
   innloggingstype: 'LEVEL4' | 'LEVEL3' | 'NAV' | 'SYSTEM'
   behandling?: Behandling
-  verge: boolean
+  erVerge: boolean
 }

--- a/din-uforetrygd-frontend/src/utils/getVisningskriterier/getVisningskriterier.test.ts
+++ b/din-uforetrygd-frontend/src/utils/getVisningskriterier/getVisningskriterier.test.ts
@@ -5,12 +5,11 @@ import { getVisningskriterier } from '@/utils/getVisningskriterier/getVisningskr
 
 const defaultUforeResponse: UforetrygdResponse = {
   pid: '81549300',
-  loggetInnSom: '81549300',
   innloggingstype: 'LEVEL4',
   sak: undefined,
   hasIverksattVedtak: false,
   uforevedtak: undefined,
-  verge: false,
+  erVerge: false,
 }
 
 const uforevedtak: DittUforevedtak = {

--- a/din-uforetrygd-frontend/src/utils/getVisningskriterier/getVisningskriterier.ts
+++ b/din-uforetrygd-frontend/src/utils/getVisningskriterier/getVisningskriterier.ts
@@ -5,7 +5,7 @@ export const getVisningskriterier = (init: UforetrygdResponse) => {
   const sak = init.sak
   const visningskriterier: Visningskriterier[] = []
 
-  if (init.verge) {
+  if (init.erVerge) {
     visningskriterier.push(Visningskriterier.ErVerge)
   }
 


### PR DESCRIPTION
Backend returnerte `isVerge`, frontend forventa `verge`. Fiksa det og forbedra navnet litt.