### PR TITLE
Fiks nullpointers

### DIFF
--- a/din-uforetrygd-frontend/src/api/hentSaksoversikt.ts
+++ b/din-uforetrygd-frontend/src/api/hentSaksoversikt.ts
@@ -28,7 +28,7 @@ export const hentSaksoversikt = async (saksid: number, pid: string | undefined) 
   })
 
   const json = await response.json().catch(() => undefined)
-  if (!response.ok && response.status === 403) {
+  if (!response.ok) {
     return { backendError: json as BackendError }
   }
   return { saksoversiktResponse: json as SaksoversiktResponse }

--- a/din-uforetrygd-frontend/src/api/initiate.ts
+++ b/din-uforetrygd-frontend/src/api/initiate.ts
@@ -24,7 +24,7 @@ export const initate = async (pid: string | undefined) => {
   const response = await fetch(`${baseUrl}/api/initiate`, { headers, cache: 'no-store' })
   const json = await response.json().catch(() => undefined)
 
-  if (!response.ok && response.status === 403) {
+  if (!response.ok) {
     return { backendError: json as BackendError }
   }
   return { uforetrygdResponse: json as UforetrygdResponse }

--- a/din-uforetrygd-frontend/src/app/page.tsx
+++ b/din-uforetrygd-frontend/src/app/page.tsx
@@ -34,7 +34,6 @@ const Home: React.FC<IHomeProps> = async ({ searchParams }) => {
   const harMottattVarsel = dineMuligheterIsEnabled ? await hentHarMottattVarsel() : false
 
   const uforevedtakPromise = hentDittUforevedtak(params.pid)
-
   const journalposterPromise = hentJournalposter(params.pid)
 
   if (uforetrygdResponse) {

--- a/din-uforetrygd-frontend/src/sections/DittVedtak/Vedtaksdetaljer.tsx
+++ b/din-uforetrygd-frontend/src/sections/DittVedtak/Vedtaksdetaljer.tsx
@@ -28,24 +28,6 @@ export function Vedtaksdetaljer({
 }: VedtaksdetaljerProps) {
   const promise = dittUforevedtakPromise
 
-  // const dittUforevedtak = use(dittUforevedtakPromise)
-  // if (!dittUforevedtak) {
-  //   return null
-  // }
-  //
-  // const uforegrad = dittUforevedtak.uforegrad
-  // const uforetidspunkt =
-  //   dittUforevedtak.uforetidspunkt && format(parseISO(dittUforevedtak.uforetidspunkt), 'dd.MM.yyyy')
-  // const uforetrygdInnvilget = dittUforevedtak.virkFom && format(parseISO(dittUforevedtak.virkFom), 'dd.MM.yyyy')
-  // const inntektsgrense = formatInntekt(dittUforevedtak.inntektsgrense) ?? 0
-  // const inntektstak = formatInntekt(dittUforevedtak.inntektstak) ?? 0
-  // const inntektFraSkatt = formatInntekt(dittUforevedtak.inntektFraSkatt)
-  // const sumAvForventedeInntekter = formatInntekt(dittUforevedtak.sumAvForventedeInntekter) ?? 0
-  // const hasVarigTilrettelagtArbeid = dittUforevedtak.hasVarigTilrettelagtArbeid
-  // const hasBarnetilleggFellesBarn = dittUforevedtak.hasBarnetilleggFellesBarn
-  // const hasBarnetilleggSaerkullsbarn = dittUforevedtak.hasBarnetilleggSaerkullsbarn
-  // const hasGjenlevendeTillegg = dittUforevedtak.hasGjenlevendeTillegg
-
   return (
     <Box>
       <HGrid gap={{ xs: 'space-32', md: 'space-0 space-40' }} columns={{ md: 2 }}>
@@ -69,16 +51,16 @@ export function Vedtaksdetaljer({
                 promise={promise}
                 fallback={<></>}
                 render={(verdi) =>
-                  (verdi!.hasGjenlevendeTillegg ||
-                    verdi!.hasBarnetilleggFellesBarn ||
-                    verdi!.hasBarnetilleggSaerkullsbarn) && (
+                  (verdi?.hasGjenlevendeTillegg ||
+                    verdi?.hasBarnetilleggFellesBarn ||
+                    verdi?.hasBarnetilleggSaerkullsbarn) && (
                     <Table.Row shadeOnHover={false}>
                       <Table.DataCell>Tillegg</Table.DataCell>
                       <Table.DataCell className={styles.dittVedtakTableSecondColumn} align="right">
                         {getTilleggsoppsummeringTekst(
-                          verdi!.hasGjenlevendeTillegg,
-                          verdi!.hasBarnetilleggFellesBarn,
-                          verdi!.hasBarnetilleggSaerkullsbarn
+                          verdi.hasGjenlevendeTillegg,
+                          verdi.hasBarnetilleggFellesBarn,
+                          verdi.hasBarnetilleggSaerkullsbarn
                         )}
                       </Table.DataCell>
                     </Table.Row>
@@ -132,8 +114,8 @@ export function Vedtaksdetaljer({
                     promise={promise}
                     render={(verdi) =>
                       getManedligBeregnetYtelseTekst(
-                        verdi!.hasGjenlevendeTillegg,
-                        verdi!.hasBarnetilleggFellesBarn || verdi!.hasBarnetilleggSaerkullsbarn
+                        verdi?.hasGjenlevendeTillegg,
+                        verdi?.hasBarnetilleggFellesBarn || verdi?.hasBarnetilleggSaerkullsbarn
                       )
                     }
                   />

--- a/din-uforetrygd-frontend/src/sections/DittVedtak/utils.ts
+++ b/din-uforetrygd-frontend/src/sections/DittVedtak/utils.ts
@@ -1,7 +1,7 @@
 export function getTilleggsoppsummeringTekst(
-  hasGjenlevendeTillegg: boolean,
-  hasBarnetilleggFellesBarn: boolean,
-  hasBarnetilleggSaerkullsbarn: boolean
+  hasGjenlevendeTillegg?: boolean,
+  hasBarnetilleggFellesBarn?: boolean,
+  hasBarnetilleggSaerkullsbarn?: boolean
 ): string {
   const parts: string[] = []
   if (hasGjenlevendeTillegg) parts.push('gjenlevendetillegg')
@@ -14,7 +14,7 @@ export function getTilleggsoppsummeringTekst(
   return result.charAt(0).toUpperCase() + result.slice(1)
 }
 
-export function getManedligBeregnetYtelseTekst(hasGjenlevendeTillegg: boolean, hasBarnetillegg: boolean): string {
+export function getManedligBeregnetYtelseTekst(hasGjenlevendeTillegg?: boolean, hasBarnetillegg?: boolean): string {
   return 'Månedlig beregnet uføretrygd'.concat(
     hasBarnetillegg && hasGjenlevendeTillegg
       ? ', barne- og gjenlevendetillegg'


### PR DESCRIPTION
PR-en fikser noen typefeil i produksjon: https://grafana.nav.cloud.nais.io/goto/ffu5i1t5g67lse?orgId=default

1. `Cannot read properties of null (reading 'hasGjenlevendeTillegg')`
2. `TypeError: Cannot read properties of undefined (reading 'map') `

Vi har kun tolket HTTP 403 som feil, ikke f.eks. 404. Hvis backenden returnerer 404 vil vi da tolke og type det som gyldig og at responsen skal inneholde verdier som ikke er der.

Vi burde nok gjøre typingen av responsene enda mer robuste, f.eks. ved å introdusere Zod eller lignende verktøy for å garantere at responsene er som forventa og håndtere feil skikkelig hvis ikke.